### PR TITLE
Theme hover on playlist play button

### DIFF
--- a/user.css
+++ b/user.css
@@ -93,6 +93,11 @@ button[aria-label=Playing],
   opacity: 0.75 !important;
 }
 
+.e-91000-button-primary:hover .e-91000-button-primary__inner:hover {
+  background-color: var(--spice-color) !important;
+  background-color: color-mix(in srgb, var(--spice-color) 86%, white 14%) !important;
+}
+
 .HbKLiGoYM4dpuK8L4TMX {
   border-radius: 50% !important;
 }

--- a/user.scss
+++ b/user.scss
@@ -111,6 +111,13 @@ button[aria-label=Playing],
   @extend .__scale_hover;
 }
 
+.e-91000-button-primary:hover .e-91000-button-primary__inner:hover {
+  // Fallback
+  background-color: var(--spice-color) !important;
+  // Dynamically mimic Spotify's two hardcoded colors: #1ed760 & #3be477
+  background-color: color-mix(in srgb, var(--spice-color) 86%, white 14%) !important;
+}
+
 // download button
 .HbKLiGoYM4dpuK8L4TMX {
   @extend .__color;


### PR DESCRIPTION
Fixes #4 

Comparison:
Default Spotify:
![GIF2-2](https://github.com/user-attachments/assets/5da3d624-b695-4166-8954-d92818bebd88)
Before PR:
![GIF3](https://github.com/user-attachments/assets/56423ecc-21ba-465b-b9fb-a331fec805ef)
After PR:
![GIF-2](https://github.com/user-attachments/assets/43f1aee7-dab5-49a7-9f4e-9f9cf3590dc7)

`color-mix(in srgb, var(--spice-color) 86%, white 14%)` was used to estimate the difference in lightness between spotify's two hardcoded greens: `#1ed760` & `#3be477`